### PR TITLE
Don't assume auto-handle; don't send self-remove

### DIFF
--- a/interop/scenario_generators/group.py
+++ b/interop/scenario_generators/group.py
@@ -69,7 +69,7 @@ class Group:
                 self.actions.append('"action": "handleCommit", "actor": "{}", "commit": {}, "byReference": {}'.format(
                     self.actors[actor],
                     commit_index,
-                    [prop for prop, sender in proposals if sender != actor],
+                    [prop for prop, sender in proposals],
                 ))
         return commit_index
     


### PR DESCRIPTION
The current script generator makes two assumptions that are not necessarily true:

1. That a client automatically cues any proposals that it creates for commit, and thus doesn't need to be instructed to commit them
2. That a client can gracefully handle a commit that removes the client

This PR makes the corresponding changes to scenario generation to accommodate the case where these are not true:

1. All proposals are explicitly signaled in `byReference`, including those created by the committer
2. A commit that removes a member is not sent to that member